### PR TITLE
Set `eval = isTRUE(l10n_info()[['UTF-8']])` to avoid CRAN check problems

### DIFF
--- a/vignettes/glossr_how.Rmd
+++ b/vignettes/glossr_how.Rmd
@@ -14,7 +14,7 @@ bibliography: ["../inst/REFERENCES.bib", "../inst/packages.bib"]
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  echo = TRUE
+  eval = isTRUE(l10n_info()[['UTF-8']])
 )
 ```
 


### PR DESCRIPTION
This should fix the CRAN check problem: https://cran.r-project.org/web/checks/check_results_glossr.html