### PR TITLE
Revert "Set `eval = isTRUE(l10n_info()[['UTF-8']])` to avoid CRAN check problems"

### DIFF
--- a/vignettes/glossr_how.Rmd
+++ b/vignettes/glossr_how.Rmd
@@ -14,7 +14,7 @@ bibliography: ["../inst/REFERENCES.bib", "../inst/packages.bib"]
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  eval = isTRUE(l10n_info()[['UTF-8']])
+  echo = TRUE
 )
 ```
 


### PR DESCRIPTION
Reverts montesmariana/glossr#3

Non-UTF locales will not be checked anymore in CRAN, so this is not necessary anymore.